### PR TITLE
change the package nickname for binary-types because the "bt" nick

### DIFF
--- a/binary-types.lisp
+++ b/binary-types.lisp
@@ -14,7 +14,7 @@
 ;;;;------------------------------------------------------------------
 
 (defpackage #:binary-types
-  (:nicknames #:bt)
+  (:nicknames #:btypes)
   (:use #:common-lisp)
   (:export #:*endian*			; [dynamic-var] must be bound when reading integers
 	   #:endianess			; [deftype] The set of endian names


### PR DESCRIPTION
caused a conflict with the nickname for the bordeaux-threads package,
which is a common package used in a great many systems. I've selected
:btypes which doesn't have the virtue of being two characters long,
but that two character nicknamespace is a very shallow pool, and
probably only the most commonly used public packages should live there.
